### PR TITLE
Fix 'default_trait_access' Clippy lint complains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Omit linting of generated code by adding `#[automatically_derived]` attribute.
 
 ## 0.5.1 - 2019-03-01
 ### Fixed

--- a/src/body_impl.rs
+++ b/src/body_impl.rs
@@ -42,6 +42,7 @@ pub fn impl_my_derive(input: &DeriveInput) -> Result<TokenStream, Error> {
         }
     };
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_generics Default for #name #ty_generics #where_clause {
             #[doc = #doc]
             fn default() -> Self {

--- a/src/body_impl.rs
+++ b/src/body_impl.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use syn::DeriveInput;
 use syn::spanned::Spanned;
 use syn::parse::Error;
-use quote::{quote, ToTokens as _};
+use quote::quote;
 
 use default_attr::{DefaultAttr, ConversionStrategy};
 use util::find_only;
@@ -122,9 +122,8 @@ fn field_default_expr_and_doc(field: &syn::Field) -> Result<(TokenStream, String
         let field_doc = format!("{}", field_value);
         Ok((field_value, field_doc))
     } else {
-        let field_type = field.ty.clone().into_token_stream();
         Ok((quote! {
-            <#field_type as Default>::default()
+            Default::default()
         }, "Default::default()".to_owned()))
     }
 }

--- a/src/body_impl.rs
+++ b/src/body_impl.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use syn::DeriveInput;
 use syn::spanned::Spanned;
 use syn::parse::Error;
-use quote::quote;
+use quote::{quote, ToTokens as _};
 
 use default_attr::{DefaultAttr, ConversionStrategy};
 use util::find_only;
@@ -122,8 +122,9 @@ fn field_default_expr_and_doc(field: &syn::Field) -> Result<(TokenStream, String
         let field_doc = format!("{}", field_value);
         Ok((field_value, field_doc))
     } else {
+        let field_type = field.ty.clone().into_token_stream();
         Ok((quote! {
-            Default::default()
+            <#field_type as core::default::Default>::default()
         }, "Default::default()".to_owned()))
     }
 }

--- a/src/body_impl.rs
+++ b/src/body_impl.rs
@@ -124,7 +124,7 @@ fn field_default_expr_and_doc(field: &syn::Field) -> Result<(TokenStream, String
     } else {
         let field_type = field.ty.clone().into_token_stream();
         Ok((quote! {
-            <#field_type as core::default::Default>::default()
+            <#field_type as Default>::default()
         }, "Default::default()".to_owned()))
     }
 }


### PR DESCRIPTION
## Synopsis

We're using `cargo clippy -- -D clippy::pedantic -D warnings` in our projects, and with these settings Clippy complains about `smart_default` not being followed [`default_trait_access` lint](https://rust-lang.github.io/rust-clippy/master/index.html#default_trait_access).

```
error: Calling std::borrow::Cow<'static, str>::default() is more clear than this expression
   --> src/conf.rs:143:48
    |
143 | #[derive(Clone, Debug, Deserialize, Serialize, SmartDefault)]
    |                                                ^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_trait_access
```



## Solution

~~Use `<#field_type as core::default::Default>::default()` in generated code instead of just `Default::default()`.~~

Place `#[automatically_derived]` attribute on top of derived implementation for being omitted by linters.



## Checklist

- [x] Tests pass
- [x] Changelog entry added