### PR TITLE
clippy formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/idanarye/rust-smart-default"
 documentation = "https://idanarye.github.io/rust-smart-default/"
 readme = "README.md"
 keywords = ["default"]
+rust-version = "1.56"
 
 [lib]
 proc-macro = true

--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ assert!(Foo::default() == Foo::Baz {
 });
 ```
 
-Requires Rust 1.30+ (for non-string values in attributes)
+Requires Rust 1.30+ (for non-string values in attributes), and version 1.56
+due to 2021 edition.

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -20,14 +20,14 @@ enum Foo {
 }
 
 fn main() {
-    assert!(
-        Foo::default()
-            == Foo::Baz {
-                a: 12,
-                b: 0,
-                c: Some(0),
-                d: vec![1, 2, 3],
-                e: "four".to_owned(),
-            }
+    assert_eq!(
+        Foo::default(),
+        Foo::Baz {
+            a: 12,
+            b: 0,
+            c: Some(0),
+            d: vec![1, 2, 3],
+            e: "four".to_owned(),
+        }
     );
 }


### PR DESCRIPTION
Great package! 

- Rust minimal supported version is (apparently?) 1.56, due to edition choice.
- Clippy hint followed in example. 
